### PR TITLE
LPS-55055

### DIFF
--- a/portal-impl/src/com/liferay/portal/lar/ExportImportHelperImpl.java
+++ b/portal-impl/src/com/liferay/portal/lar/ExportImportHelperImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.lar.DefaultConfigurationPortletDataHandler;
 import com.liferay.portal.kernel.lar.ExportImportDateUtil;
 import com.liferay.portal.kernel.lar.ExportImportHelper;
 import com.liferay.portal.kernel.lar.ExportImportPathUtil;
+import com.liferay.portal.kernel.lar.ExportImportThreadLocal;
 import com.liferay.portal.kernel.lar.ManifestSummary;
 import com.liferay.portal.kernel.lar.MissingReference;
 import com.liferay.portal.kernel.lar.MissingReferences;
@@ -46,6 +47,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.CharPool;
+import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.DateRange;
 import com.liferay.portal.kernel.util.Digester;
@@ -61,6 +63,7 @@ import com.liferay.portal.kernel.util.StreamUtil;
 import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.SystemProperties;
 import com.liferay.portal.kernel.util.TempFileEntryUtil;
 import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.kernel.util.Validator;
@@ -70,6 +73,8 @@ import com.liferay.portal.kernel.xml.ElementHandler;
 import com.liferay.portal.kernel.xml.ElementProcessor;
 import com.liferay.portal.kernel.zip.ZipReader;
 import com.liferay.portal.kernel.zip.ZipReaderFactoryUtil;
+import com.liferay.portal.kernel.zip.ZipWriter;
+import com.liferay.portal.kernel.zip.ZipWriterFactoryUtil;
 import com.liferay.portal.model.Company;
 import com.liferay.portal.model.Group;
 import com.liferay.portal.model.GroupConstants;
@@ -689,6 +694,25 @@ public class ExportImportHelperImpl implements ExportImportHelper {
 		}
 
 		return new CurrentUserIdStrategy(user);
+	}
+
+	@Override
+	public ZipWriter getZipWriter(
+		long groupId, Map<String, String[]> parameterMap) {
+
+		if (!ExportImportThreadLocal.isStagingInProcess() ||
+			(PropsValues.STAGING_DELETE_TEMP_LAR_ON_FAILURE &&
+			 PropsValues.STAGING_DELETE_TEMP_LAR_ON_SUCCESS)) {
+
+			return ZipWriterFactoryUtil.getZipWriter();
+		}
+
+		File file = new File(
+			SystemProperties.get(SystemProperties.TMP_DIR) + StringPool.SLASH +
+			MapUtil.getString(parameterMap, Constants.CMD) + StringPool.DASH +
+			groupId + StringPool.DASH + Time.getShortTimestamp() + ".lar");
+
+		return ZipWriterFactoryUtil.getZipWriter(file);
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/lar/LayoutExporter.java
+++ b/portal-impl/src/com/liferay/portal/lar/LayoutExporter.java
@@ -56,14 +56,12 @@ import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.ReleaseInfo;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.kernel.util.SystemProperties;
 import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.xml.Document;
 import com.liferay.portal.kernel.xml.Element;
 import com.liferay.portal.kernel.xml.SAXReaderUtil;
 import com.liferay.portal.kernel.zip.ZipWriter;
-import com.liferay.portal.kernel.zip.ZipWriterFactoryUtil;
 import com.liferay.portal.model.Group;
 import com.liferay.portal.model.Image;
 import com.liferay.portal.model.Layout;
@@ -90,7 +88,6 @@ import com.liferay.portal.service.ServiceContext;
 import com.liferay.portal.service.ServiceContextThreadLocal;
 import com.liferay.portal.service.UserLocalServiceUtil;
 import com.liferay.portal.service.permission.PortletPermissionUtil;
-import com.liferay.portal.util.PropsValues;
 
 import java.io.File;
 
@@ -761,24 +758,8 @@ public class LayoutExporter {
 
 		Group group = GroupLocalServiceUtil.getGroup(groupId);
 
-		ZipWriter zipWriter;
-
-		if (!ExportImportThreadLocal.isStagingInProcess() ||
-			(PropsValues.STAGING_DELETE_TEMP_LAR_ON_FAILURE &&
-			 PropsValues.STAGING_DELETE_TEMP_LAR_ON_SUCCESS)) {
-
-			zipWriter = ZipWriterFactoryUtil.getZipWriter();
-		}
-		else {
-			File file = new File(
-				SystemProperties.get(SystemProperties.TMP_DIR) +
-				StringPool.SLASH + MapUtil.getString(
-					parameterMap, Constants.CMD) +
-				StringPool.DASH + groupId + StringPool.DASH +
-				Time.getShortTimestamp() + ".lar");
-
-			zipWriter = ZipWriterFactoryUtil.getZipWriter(file);
-		}
+		ZipWriter zipWriter = ExportImportHelperUtil.getZipWriter(
+			groupId, parameterMap);
 
 		PortletDataContext portletDataContext =
 			PortletDataContextFactoryUtil.createExportPortletDataContext(

--- a/portal-impl/src/com/liferay/portal/lar/LayoutExporter.java
+++ b/portal-impl/src/com/liferay/portal/lar/LayoutExporter.java
@@ -56,6 +56,7 @@ import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.ReleaseInfo;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.SystemProperties;
 import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.xml.Document;
@@ -89,6 +90,7 @@ import com.liferay.portal.service.ServiceContext;
 import com.liferay.portal.service.ServiceContextThreadLocal;
 import com.liferay.portal.service.UserLocalServiceUtil;
 import com.liferay.portal.service.permission.PortletPermissionUtil;
+import com.liferay.portal.util.PropsValues;
 
 import java.io.File;
 
@@ -759,10 +761,29 @@ public class LayoutExporter {
 
 		Group group = GroupLocalServiceUtil.getGroup(groupId);
 
+		ZipWriter zipWriter;
+
+		if (!ExportImportThreadLocal.isStagingInProcess() ||
+			(PropsValues.STAGING_DELETE_TEMP_LAR_ON_FAILURE &&
+			 PropsValues.STAGING_DELETE_TEMP_LAR_ON_SUCCESS)) {
+
+			zipWriter = ZipWriterFactoryUtil.getZipWriter();
+		}
+		else {
+			File file = new File(
+				SystemProperties.get(SystemProperties.TMP_DIR) +
+				StringPool.SLASH + MapUtil.getString(
+					parameterMap, Constants.CMD) +
+				StringPool.DASH + groupId + StringPool.DASH +
+				Time.getShortTimestamp() + ".lar");
+
+			zipWriter = ZipWriterFactoryUtil.getZipWriter(file);
+		}
+
 		PortletDataContext portletDataContext =
 			PortletDataContextFactoryUtil.createExportPortletDataContext(
 				group.getCompanyId(), groupId, parameterMap, startDate, endDate,
-				ZipWriterFactoryUtil.getZipWriter());
+				zipWriter);
 
 		portletDataContext.setPrivateLayout(privateLayout);
 

--- a/portal-impl/src/com/liferay/portal/lar/PortletExporter.java
+++ b/portal-impl/src/com/liferay/portal/lar/PortletExporter.java
@@ -42,6 +42,7 @@ import com.liferay.portal.kernel.lar.lifecycle.ExportImportLifecycleManager;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.CharPool;
+import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.DateRange;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.MapUtil;
@@ -49,6 +50,7 @@ import com.liferay.portal.kernel.util.ReleaseInfo;
 import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.SystemProperties;
 import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.Validator;
@@ -79,6 +81,7 @@ import com.liferay.portal.service.ServiceContextThreadLocal;
 import com.liferay.portal.service.UserLocalServiceUtil;
 import com.liferay.portal.util.PortalUtil;
 import com.liferay.portal.util.PortletKeys;
+import com.liferay.portal.util.PropsValues;
 import com.liferay.portlet.PortletPreferencesFactoryUtil;
 import com.liferay.portlet.asset.model.AssetEntry;
 import com.liferay.portlet.asset.model.AssetLink;
@@ -1142,7 +1145,24 @@ public class PortletExporter {
 
 		Layout layout = LayoutLocalServiceUtil.getLayout(plid);
 
-		ZipWriter zipWriter = ZipWriterFactoryUtil.getZipWriter();
+		ZipWriter zipWriter;
+
+		if (!ExportImportThreadLocal.isStagingInProcess() ||
+			(PropsValues.STAGING_DELETE_TEMP_LAR_ON_FAILURE &&
+			 PropsValues.STAGING_DELETE_TEMP_LAR_ON_SUCCESS)) {
+
+			zipWriter = ZipWriterFactoryUtil.getZipWriter();
+		}
+		else {
+			File file = new File(
+				SystemProperties.get(SystemProperties.TMP_DIR) +
+				StringPool.SLASH + MapUtil.getString(
+					parameterMap, Constants.CMD) +
+				StringPool.DASH + groupId + StringPool.DASH +
+				Time.getShortTimestamp() + ".lar");
+
+			zipWriter = ZipWriterFactoryUtil.getZipWriter(file);
+		}
 
 		PortletDataContext portletDataContext =
 			PortletDataContextFactoryUtil.createExportPortletDataContext(

--- a/portal-impl/src/com/liferay/portal/lar/PortletExporter.java
+++ b/portal-impl/src/com/liferay/portal/lar/PortletExporter.java
@@ -42,7 +42,6 @@ import com.liferay.portal.kernel.lar.lifecycle.ExportImportLifecycleManager;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.CharPool;
-import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.DateRange;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.MapUtil;
@@ -50,7 +49,6 @@ import com.liferay.portal.kernel.util.ReleaseInfo;
 import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.kernel.util.SystemProperties;
 import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.Validator;
@@ -59,7 +57,6 @@ import com.liferay.portal.kernel.xml.Element;
 import com.liferay.portal.kernel.xml.Node;
 import com.liferay.portal.kernel.xml.SAXReaderUtil;
 import com.liferay.portal.kernel.zip.ZipWriter;
-import com.liferay.portal.kernel.zip.ZipWriterFactoryUtil;
 import com.liferay.portal.model.Group;
 import com.liferay.portal.model.Layout;
 import com.liferay.portal.model.LayoutConstants;
@@ -81,7 +78,6 @@ import com.liferay.portal.service.ServiceContextThreadLocal;
 import com.liferay.portal.service.UserLocalServiceUtil;
 import com.liferay.portal.util.PortalUtil;
 import com.liferay.portal.util.PortletKeys;
-import com.liferay.portal.util.PropsValues;
 import com.liferay.portlet.PortletPreferencesFactoryUtil;
 import com.liferay.portlet.asset.model.AssetEntry;
 import com.liferay.portlet.asset.model.AssetLink;
@@ -1145,24 +1141,8 @@ public class PortletExporter {
 
 		Layout layout = LayoutLocalServiceUtil.getLayout(plid);
 
-		ZipWriter zipWriter;
-
-		if (!ExportImportThreadLocal.isStagingInProcess() ||
-			(PropsValues.STAGING_DELETE_TEMP_LAR_ON_FAILURE &&
-			 PropsValues.STAGING_DELETE_TEMP_LAR_ON_SUCCESS)) {
-
-			zipWriter = ZipWriterFactoryUtil.getZipWriter();
-		}
-		else {
-			File file = new File(
-				SystemProperties.get(SystemProperties.TMP_DIR) +
-				StringPool.SLASH + MapUtil.getString(
-					parameterMap, Constants.CMD) +
-				StringPool.DASH + groupId + StringPool.DASH +
-				Time.getShortTimestamp() + ".lar");
-
-			zipWriter = ZipWriterFactoryUtil.getZipWriter(file);
-		}
+		ZipWriter zipWriter = ExportImportHelperUtil.getZipWriter(
+			groupId, parameterMap);
 
 		PortletDataContext portletDataContext =
 			PortletDataContextFactoryUtil.createExportPortletDataContext(

--- a/portal-service/src/com/liferay/portal/kernel/lar/ExportImportHelper.java
+++ b/portal-service/src/com/liferay/portal/kernel/lar/ExportImportHelper.java
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.util.DateRange;
 import com.liferay.portal.kernel.xml.Document;
 import com.liferay.portal.kernel.xml.Element;
+import com.liferay.portal.kernel.zip.ZipWriter;
 import com.liferay.portal.model.Layout;
 import com.liferay.portal.model.Portlet;
 import com.liferay.portal.model.StagedModel;
@@ -223,6 +224,9 @@ public interface ExportImportHelper {
 
 	public UserIdStrategy getUserIdStrategy(long userId, String userIdStrategy)
 		throws PortalException;
+
+	public ZipWriter getZipWriter(
+		long groupId, Map<String, String[]> parameterMap);
 
 	public boolean isReferenceWithinExportScope(
 		PortletDataContext portletDataContext, StagedModel stagedModel);

--- a/portal-service/src/com/liferay/portal/kernel/lar/ExportImportHelperUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/lar/ExportImportHelperUtil.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.security.pacl.permission.PortalRuntimePermissio
 import com.liferay.portal.kernel.util.DateRange;
 import com.liferay.portal.kernel.xml.Document;
 import com.liferay.portal.kernel.xml.Element;
+import com.liferay.portal.kernel.zip.ZipWriter;
 import com.liferay.portal.model.Layout;
 import com.liferay.portal.model.Portlet;
 import com.liferay.portal.model.StagedModel;
@@ -299,6 +300,12 @@ public class ExportImportHelperUtil {
 
 		return getExportImportHelper().getUserIdStrategy(
 			userId, userIdStrategy);
+	}
+
+	public static ZipWriter getZipWriter(
+		long groupId, Map<String, String[]> parameterMap) {
+
+		return getExportImportHelper().getZipWriter(groupId, parameterMap);
 	}
 
 	public static boolean isReferenceWithinExportScope(


### PR DESCRIPTION
At https://github.com/liferay/liferay-portal/blob/master/portal-impl/src/com/liferay/portal/zip/ZipWriterImpl.java#L51-54 it is registered the **DeleteFileFinalizeAction** to delete the File in case of GC of the object, so temporary LAR object was deleted sometimes even if you configure the properties of LPS-53879 to false

To avoid this deletion, I am calling **ZipWriterImpl(java.io.File file)** constructor https://github.com/liferay/liferay-portal/blob/master/portal-impl/src/com/liferay/portal/zip/ZipWriterImpl.java#L57 when you configure to not delete the LAR file.