### PR TITLE
[LPS-63916] First 'Ready for publication' page version not listed in the history, right after enabling page versioning

### DIFF
--- a/portal-impl/src/com/liferay/portal/model/impl/LayoutRevisionImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/LayoutRevisionImpl.java
@@ -35,6 +35,7 @@ import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
 import java.util.List;
 import java.util.Locale;
@@ -252,6 +253,15 @@ public class LayoutRevisionImpl extends LayoutRevisionBaseImpl {
 		else {
 			return false;
 		}
+	}
+
+	@Override
+	public void setStatus(int status) {
+		if (status == WorkflowConstants.STATUS_APPROVED) {
+			super.setMajor(true);
+		}
+
+		super.setStatus(status);
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutBranchLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutBranchLocalServiceImpl.java
@@ -99,7 +99,7 @@ public class LayoutBranchLocalServiceImpl
 		layoutRevisionLocalService.addLayoutRevision(
 			layoutBranch.getUserId(), layoutRevision.getLayoutSetBranchId(),
 			layoutBranch.getLayoutBranchId(),
-			LayoutRevisionConstants.DEFAULT_PARENT_LAYOUT_REVISION_ID, false,
+			LayoutRevisionConstants.DEFAULT_PARENT_LAYOUT_REVISION_ID, true,
 			layoutRevision.getPlid(), layoutRevision.getLayoutRevisionId(),
 			layoutRevision.isPrivateLayout(), layoutRevision.getName(),
 			layoutRevision.getTitle(), layoutRevision.getDescription(),

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutRevisionLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutRevisionLocalServiceImpl.java
@@ -92,7 +92,7 @@ public class LayoutRevisionLocalServiceImpl
 		layoutRevision.setThemeId(themeId);
 		layoutRevision.setColorSchemeId(colorSchemeId);
 		layoutRevision.setCss(css);
-		layoutRevision.setStatus(WorkflowConstants.STATUS_DRAFT);
+		layoutRevision.setStatus(WorkflowConstants.STATUS_APPROVED);
 		layoutRevision.setStatusDate(serviceContext.getModifiedDate(now));
 
 		layoutRevisionPersistence.update(layoutRevision);


### PR DESCRIPTION
Hi,

I have made the changes we have discussed.

To make the new layoutrevision and layoutbranch approved and head by default.
And to ensure every approved version is major.
There are two problems this aims to fix:
1. When page versioning is switched on, the first revision was head, approved, but not major. when clicking ready for publication after modifications, every not major revision is deleted, so the initial revision was deleted too.
2. When a new site page variation is created it's status was draft and it was head, so in revision history it appeared with draft style, but Ready for publication message.

I think this is not complete, because I have experienced odd behavior on history view, when there were any site variations, and used ready for publication on the bar, or i clicked mark as ready for publication using the history's action button.

Please review.

Thanks.