### PR TITLE
Check the cache file again for newer one bypassing concurrency problems

### DIFF
--- a/portal-impl/src/com/liferay/portlet/sites/util/SitesImpl.java
+++ b/portal-impl/src/com/liferay/portlet/sites/util/SitesImpl.java
@@ -1898,9 +1898,9 @@ public class SitesImpl implements Sites {
 
 		File cacheFile = new File(sb.toString());
 
-		if (cacheFile.exists() && !importData) {
-			Date modifiedDate = layoutSetPrototype.getModifiedDate();
+		Date modifiedDate = layoutSetPrototype.getModifiedDate();
 
+		if (cacheFile.exists() && !importData) {
 			if (cacheFile.lastModified() >= modifiedDate.getTime()) {
 				if (_log.isDebugEnabled()) {
 					_log.debug(
@@ -1963,12 +1963,23 @@ public class SitesImpl implements Sites {
 
 		if (newFile) {
 			try {
-				FileUtil.copyFile(file, cacheFile);
+				if (!cacheFile.exists() ||
+					(cacheFile.lastModified() < modifiedDate.getTime())) {
 
-				if (_log.isDebugEnabled()) {
-					_log.debug(
-						"Copied " + file.getAbsolutePath() + " to " +
-							cacheFile.getAbsolutePath());
+					FileUtil.copyFile(file, cacheFile);
+
+					if (_log.isDebugEnabled()) {
+						_log.debug(
+							"Copied " + file.getAbsolutePath() + " to " +
+								cacheFile.getAbsolutePath());
+					}
+				} else {
+					if (_log.isDebugEnabled()) {
+						_log.debug(
+							"Not copied " + file.getAbsolutePath() + " to " +
+							cacheFile.getAbsolutePath() + " as that " +
+							"existed containing the latest data");
+					}
 				}
 			}
 			catch (Exception e) {


### PR DESCRIPTION
Hi,

here is a proposal to solve concurrent file access problems at syncing site template pages to sites.

It can be reproducible if there are several ongoing site merging from the same site template in the very same time. In this case, exceptions may occur that is described here: https://java.net/projects/truezip/lists/users/archive/2007-12/message/6

The new log message can be removed or rephrased.

Regards,
Zsigmond