### PR TITLE
LPS-68898

### DIFF
--- a/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/controller/PortletExportController.java
+++ b/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/controller/PortletExportController.java
@@ -333,14 +333,14 @@ public class PortletExportController implements ExportController {
 			exportPortletPreferences(
 				portletDataContext, portletDataContext.getCompanyId(),
 				PortletKeys.PREFS_OWNER_TYPE_COMPANY, false, layout, plid,
-				portlet.getRootPortletId(), portletElement);
+				portlet.getPortletId(), portletElement);
 
 			// Group
 
 			exportPortletPreferences(
 				portletDataContext, portletDataContext.getScopeGroupId(),
 				PortletKeys.PREFS_OWNER_TYPE_GROUP, false, layout,
-				PortletKeys.PREFS_PLID_SHARED, portlet.getRootPortletId(),
+				PortletKeys.PREFS_PLID_SHARED, portlet.getPortletId(),
 				portletElement);
 
 			// Layout

--- a/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/controller/PortletImportController.java
+++ b/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/controller/PortletImportController.java
@@ -418,7 +418,6 @@ public class PortletImportController implements ImportController {
 
 				if (ownerType == PortletKeys.PREFS_OWNER_TYPE_GROUP) {
 					curPlid = PortletKeys.PREFS_PLID_SHARED;
-					curPortletId = portletDataContext.getRootPortletId();
 					ownerId = portletDataContext.getScopeGroupId();
 				}
 

--- a/modules/apps/web-experience/portlet-configuration/portlet-configuration-web/src/main/java/com/liferay/portlet/configuration/web/internal/portlet/PortletConfigurationPortlet.java
+++ b/modules/apps/web-experience/portlet-configuration/portlet-configuration-web/src/main/java/com/liferay/portlet/configuration/web/internal/portlet/PortletConfigurationPortlet.java
@@ -850,7 +850,7 @@ public class PortletConfigurationPortlet extends MVCPortlet {
 
 		PortletPreferencesIds portletPreferencesIds = new PortletPreferencesIds(
 			themeDisplay.getCompanyId(), layout.getGroupId(),
-			PortletKeys.PREFS_OWNER_TYPE_LAYOUT, PortletKeys.PREFS_PLID_SHARED,
+			PortletKeys.PREFS_OWNER_TYPE_GROUP, PortletKeys.PREFS_PLID_SHARED,
 			portletId);
 
 		return _portletPreferencesLocalService.getPreferences(

--- a/portal-impl/src/com/liferay/portal/model/impl/LayoutImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/LayoutImpl.java
@@ -1351,7 +1351,7 @@ public class LayoutImpl extends LayoutBaseImpl {
 	private List<PortletPreferences> _getPortletPreferences(long groupId) {
 		List<PortletPreferences> portletPreferences =
 			PortletPreferencesLocalServiceUtil.getPortletPreferences(
-				groupId, PortletKeys.PREFS_OWNER_TYPE_LAYOUT,
+				groupId, PortletKeys.PREFS_OWNER_TYPE_GROUP,
 				PortletKeys.PREFS_PLID_SHARED);
 
 		if (isTypePortlet()) {

--- a/portal-impl/src/com/liferay/portlet/PortletPreferencesFactoryImpl.java
+++ b/portal-impl/src/com/liferay/portlet/PortletPreferencesFactoryImpl.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutConstants;
+import com.liferay.portal.kernel.model.LayoutRevision;
 import com.liferay.portal.kernel.model.LayoutTypePortlet;
 import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.model.PortletConstants;
@@ -39,7 +40,8 @@ import com.liferay.portal.kernel.security.pacl.DoPrivileged;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
-import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
+import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
+import com.liferay.portal.kernel.service.LayoutRevisionLocalServiceUtil;
 import com.liferay.portal.kernel.service.PortalPreferencesLocalServiceUtil;
 import com.liferay.portal.kernel.service.PortletLocalServiceUtil;
 import com.liferay.portal.kernel.service.PortletPreferencesLocalServiceUtil;
@@ -431,15 +433,6 @@ public class PortletPreferencesFactoryImpl
 		PermissionChecker permissionChecker =
 			PermissionThreadLocal.getPermissionChecker();
 
-		String originalPortletId = portletId;
-
-		Portlet portlet = PortletLocalServiceUtil.getPortletById(
-			layout.getCompanyId(), portletId);
-
-		long ownerId = 0;
-		int ownerType = 0;
-		long plid = 0;
-
 		if (modeEditGuest) {
 			boolean hasUpdateLayoutPermission = LayoutPermissionUtil.contains(
 				permissionChecker, layout, ActionKeys.UPDATE);
@@ -457,67 +450,35 @@ public class PortletPreferencesFactoryImpl
 			}
 		}
 
-		if (PortletConstants.hasUserId(originalPortletId) &&
-			(PortletConstants.getUserId(originalPortletId) == userId)) {
+		boolean useDefaultUserId = false;
 
-			ownerId = userId;
-			ownerType = PortletKeys.PREFS_OWNER_TYPE_USER;
-			plid = layout.getPlid();
-		}
-		else if (portlet.isPreferencesCompanyWide()) {
-			ownerId = layout.getCompanyId();
-			ownerType = PortletKeys.PREFS_OWNER_TYPE_COMPANY;
-			plid = PortletKeys.PREFS_PLID_SHARED;
-			portletId = PortletConstants.getRootPortletId(portletId);
-		}
-		else {
-			if (portlet.isPreferencesUniquePerLayout()) {
-				ownerId = PortletKeys.PREFS_OWNER_ID_DEFAULT;
-				ownerType = PortletKeys.PREFS_OWNER_TYPE_LAYOUT;
-				plid = layout.getPlid();
+		Portlet portlet = PortletLocalServiceUtil.getPortletById(
+			layout.getCompanyId(), portletId);
 
-				LayoutTypePortlet layoutTypePortlet =
-					(LayoutTypePortlet)layout.getLayoutType();
+		if (PortletConstants.hasUserId(portletId) ||
+			(PortletConstants.getUserId(portletId) != userId)) {
 
-				if (layoutTypePortlet.isPortletEmbedded(portletId)) {
-					ownerId = layout.getGroupId();
-					plid = PortletKeys.PREFS_PLID_SHARED;
-				}
-
-				if (portlet.isPreferencesOwnedByGroup()) {
-				}
-				else {
-					if ((userId <= 0) || modeEditGuest) {
-						userId = UserLocalServiceUtil.getDefaultUserId(
-							layout.getCompanyId());
-					}
-
-					ownerId = userId;
-					ownerType = PortletKeys.PREFS_OWNER_TYPE_USER;
-				}
+			if (modeEditGuest) {
+				useDefaultUserId = true;
 			}
-			else {
-				plid = PortletKeys.PREFS_PLID_SHARED;
-
-				if (portlet.isPreferencesOwnedByGroup()) {
-					ownerId = siteGroupId;
-					ownerType = PortletKeys.PREFS_OWNER_TYPE_GROUP;
-					portletId = PortletConstants.getRootPortletId(portletId);
-				}
-				else {
-					if ((userId <= 0) || modeEditGuest) {
-						userId = UserLocalServiceUtil.getDefaultUserId(
-							layout.getCompanyId());
-					}
-
-					ownerId = userId;
-					ownerType = PortletKeys.PREFS_OWNER_TYPE_USER;
-				}
+		}
+		else if (!portlet.isPreferencesCompanyWide()) {
+			if (!portlet.isPreferencesOwnedByGroup() && (userId <= 0)) {
+				useDefaultUserId = true;
 			}
 		}
 
-		return new PortletPreferencesIds(
-			layout.getCompanyId(), ownerId, ownerType, plid, portletId);
+		if (useDefaultUserId) {
+			userId = UserLocalServiceUtil.getDefaultUserId(
+				layout.getCompanyId());
+		}
+
+		boolean isPortletEmbedded = layout.isPortletEmbedded(
+			portletId, layout.getGroupId());
+
+		return _getPortletPreferencesIds(
+			layout.getCompanyId(), siteGroupId, layout.getGroupId(), userId,
+			layout.getPlid(), portletId, isPortletEmbedded);
 	}
 
 	@Override
@@ -814,72 +775,48 @@ public class PortletPreferencesFactoryImpl
 		long companyId, long siteGroupId, long layoutGroupId, long plid,
 		String portletId, String defaultPreferences, boolean strictMode) {
 
-		String originalPortletId = portletId;
+		long userId = PortletConstants.getUserId(portletId);
 
-		Portlet portlet = PortletLocalServiceUtil.getPortletById(
-			companyId, portletId);
+		boolean isPortletEmbedded = false;
 
-		boolean uniquePerLayout = false;
-		boolean uniquePerGroup = false;
+		Layout layout = LayoutLocalServiceUtil.fetchLayout(plid);
 
-		if (portlet.isPreferencesCompanyWide()) {
-			portletId = PortletConstants.getRootPortletId(portletId);
+		if (layout != null) {
+			isPortletEmbedded = layout.isPortletEmbedded(
+				portletId, layoutGroupId);
 		}
 		else {
-			if (portlet.isPreferencesUniquePerLayout()) {
-				uniquePerLayout = true;
+			LayoutRevision layoutRevision =
+				LayoutRevisionLocalServiceUtil.fetchLayoutRevision(plid);
 
-				if (portlet.isPreferencesOwnedByGroup()) {
-					uniquePerGroup = true;
-				}
-			}
-			else {
-				if (portlet.isPreferencesOwnedByGroup()) {
-					uniquePerGroup = true;
-					portletId = PortletConstants.getRootPortletId(portletId);
-				}
+			if (layoutRevision != null) {
+				layout = LayoutLocalServiceUtil.fetchLayout(
+					layoutRevision.getPlid());
+
+				isPortletEmbedded = layout.isPortletEmbedded(
+					portletId, layoutGroupId);
 			}
 		}
 
-		long ownerId = PortletKeys.PREFS_OWNER_ID_DEFAULT;
-		int ownerType = PortletKeys.PREFS_OWNER_TYPE_LAYOUT;
-
-		Group group = GroupLocalServiceUtil.fetchGroup(siteGroupId);
-
-		if ((group != null) && group.isLayout()) {
-			plid = group.getClassPK();
+		if (siteGroupId == LayoutConstants.DEFAULT_PLID) {
+			siteGroupId = layoutGroupId;
 		}
 
-		if (PortletConstants.hasUserId(originalPortletId)) {
-			ownerId = PortletConstants.getUserId(originalPortletId);
-			ownerType = PortletKeys.PREFS_OWNER_TYPE_USER;
-		}
-		else if (!uniquePerLayout) {
-			plid = PortletKeys.PREFS_PLID_SHARED;
-
-			if (uniquePerGroup) {
-				if (siteGroupId > LayoutConstants.DEFAULT_PLID) {
-					ownerId = siteGroupId;
-				}
-				else {
-					ownerId = layoutGroupId;
-				}
-
-				ownerType = PortletKeys.PREFS_OWNER_TYPE_GROUP;
-			}
-			else {
-				ownerId = companyId;
-				ownerType = PortletKeys.PREFS_OWNER_TYPE_COMPANY;
-			}
-		}
+		PortletPreferencesIds portletPreferencesIds = _getPortletPreferencesIds(
+			companyId, siteGroupId, layoutGroupId, userId, plid, portletId,
+			isPortletEmbedded);
 
 		if (strictMode) {
 			return PortletPreferencesLocalServiceUtil.getStrictPreferences(
-				companyId, ownerId, ownerType, plid, portletId);
+				portletPreferencesIds);
 		}
 
 		return PortletPreferencesLocalServiceUtil.getPreferences(
-			companyId, ownerId, ownerType, plid, portletId, defaultPreferences);
+			portletPreferencesIds.getCompanyId(),
+			portletPreferencesIds.getOwnerId(),
+			portletPreferencesIds.getOwnerType(),
+			portletPreferencesIds.getPlid(),
+			portletPreferencesIds.getPortletId(), defaultPreferences);
 	}
 
 	protected Map<String, Preference> toPreferencesMap(String xml) {
@@ -919,6 +856,63 @@ public class PortletPreferencesFactoryImpl
 		}
 
 		return String.valueOf(cacheKeyGenerator.getCacheKey(xml));
+	}
+
+	private PortletPreferencesIds _getPortletPreferencesIds(
+		long companyId, long siteGroupId, long layoutGroupId, long userId,
+		long plid, String portletId, boolean isPortletEmbedded) {
+
+		Portlet portlet = PortletLocalServiceUtil.getPortletById(
+			companyId, portletId);
+
+		long ownerId = 0;
+		int ownerType = 0;
+
+		if (PortletConstants.hasUserId(portletId) &&
+			(PortletConstants.getUserId(portletId) == userId)) {
+
+			ownerId = userId;
+			ownerType = PortletKeys.PREFS_OWNER_TYPE_USER;
+		}
+		else if (portlet.isPreferencesCompanyWide()) {
+			ownerId = companyId;
+			ownerType = PortletKeys.PREFS_OWNER_TYPE_COMPANY;
+			plid = PortletKeys.PREFS_PLID_SHARED;
+			portletId = PortletConstants.getRootPortletId(portletId);
+		}
+		else {
+			if (portlet.isPreferencesUniquePerLayout()) {
+				ownerId = PortletKeys.PREFS_OWNER_ID_DEFAULT;
+				ownerType = PortletKeys.PREFS_OWNER_TYPE_LAYOUT;
+
+				if (isPortletEmbedded) {
+					ownerId = layoutGroupId;
+					ownerType = PortletKeys.PREFS_OWNER_TYPE_GROUP;
+					plid = PortletKeys.PREFS_PLID_SHARED;
+				}
+
+				if (!portlet.isPreferencesOwnedByGroup()) {
+					ownerId = userId;
+					ownerType = PortletKeys.PREFS_OWNER_TYPE_USER;
+				}
+			}
+			else {
+				plid = PortletKeys.PREFS_PLID_SHARED;
+
+				if (portlet.isPreferencesOwnedByGroup()) {
+					ownerId = siteGroupId;
+					ownerType = PortletKeys.PREFS_OWNER_TYPE_GROUP;
+					portletId = PortletConstants.getRootPortletId(portletId);
+				}
+				else {
+					ownerId = userId;
+					ownerType = PortletKeys.PREFS_OWNER_TYPE_USER;
+				}
+			}
+		}
+
+		return new PortletPreferencesIds(
+			companyId, ownerId, ownerType, plid, portletId);
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/util-taglib/src/com/liferay/taglib/portletext/RuntimeTag.java
+++ b/util-taglib/src/com/liferay/taglib/portletext/RuntimeTag.java
@@ -247,7 +247,7 @@ public class RuntimeTag extends TagSupport {
 
 				PortletPreferencesFactoryUtil.getLayoutPortletSetup(
 					themeDisplay.getCompanyId(), themeDisplay.getScopeGroupId(),
-					PortletKeys.PREFS_OWNER_TYPE_LAYOUT,
+					PortletKeys.PREFS_OWNER_TYPE_GROUP,
 					PortletKeys.PREFS_PLID_SHARED,
 					portletInstance.getPortletInstanceKey(),
 					defaultPreferences);
@@ -255,9 +255,10 @@ public class RuntimeTag extends TagSupport {
 				writeJSONObject = true;
 			}
 
-			if (PortletPreferencesLocalServiceUtil.getPortletPreferencesCount(
+			if (!layoutTypePortlet.isPortletEmbedded(portlet.getPortletId()) &&
+				(PortletPreferencesLocalServiceUtil.getPortletPreferencesCount(
 					PortletKeys.PREFS_OWNER_TYPE_LAYOUT, themeDisplay.getPlid(),
-					portletInstance.getPortletInstanceKey()) < 1) {
+					portletInstance.getPortletInstanceKey()) < 1)) {
 
 				PortletPreferencesFactoryUtil.getLayoutPortletSetup(
 					layout, portletInstance.getPortletInstanceKey(),


### PR DESCRIPTION
Hi @danielkocsis,

The issue is that embedded portlet preferences are being being exported and imported correctly. This commit is doing the following:
1. Using portlet ID instead of root portlet ID since we should always be getting the actual portlet. This is necessary because the Web Content Display portlet is considered instanceable so getting the root portlet ID will be incorrect and the preferences won't be exported/imported correctly. This changes LPS-30387 but it is necessary to trust what is in the preferences or LAR so that we can correctly import/export embedded portlets.
2. Using the group owner type when passing the group ID to the preferences instead of using the layout owner type with a group ID which causes a mismatch.
3. Rearranging how preferences are retrieved so that the embedded logic is used across the board. Without this change, the correct preferences for embedded portlets are not retrieved since it tries to fetch the layout's preferences instead of the group's.

Please let me know if you have any questions. Thanks!
