### PR TITLE
[TECHNICAL-SUPPORT] LPS-69904

### DIFF
--- a/modules/apps/web-experience/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/ExportImportDateUtilTest.java
+++ b/modules/apps/web-experience/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/ExportImportDateUtilTest.java
@@ -356,6 +356,32 @@ public class ExportImportDateUtilTest {
 	}
 
 	@Test
+	public void testUpdateLastPublishDateWithoutExistingLastPublishDate()
+		throws Exception {
+
+		PortletDataContext portletDataContext = new PortletDataContextImpl(
+			null);
+
+		portletDataContext.setGroupId(_group.getGroupId());
+
+		Date now = new Date();
+
+		updateLastPublishDate(
+			portletDataContext,
+			ExportImportDateUtil.RANGE_FROM_LAST_PUBLISH_DATE, now);
+
+		DateRange dateRange = new DateRange(null, now);
+
+		ExportImportDateUtil.updateLastPublishDate(
+			PortletKeys.EXPORT_IMPORT, _portletPreferences, dateRange, now);
+
+		Date lastPublishDate = ExportImportDateUtil.getLastPublishDate(
+			_portletPreferences);
+
+		Assert.assertNotNull(lastPublishDate);
+	}
+
+	@Test
 	public void testUpdateLastPublishDateWithoutGapLayoutSet()
 		throws Exception {
 

--- a/portal-kernel/src/com/liferay/exportimport/kernel/lar/ExportImportDateUtil.java
+++ b/portal-kernel/src/com/liferay/exportimport/kernel/lar/ExportImportDateUtil.java
@@ -524,7 +524,7 @@ public class ExportImportDateUtil {
 				return false;
 			}
 		}
-		else if ((startDate != null) || (endDate != null)) {
+		else if (startDate != null) {
 			return false;
 		}
 


### PR DESCRIPTION
Resending changes from https://github.com/danielkocsis/liferay-portal/pull/590, with an added test for this case, as per request. I only created one because to me, it seems to be a very specific use case. I can add more if you can think of other ways to test this though.

Also, although it's particular to the client, I'd be interested to hear if you had any more suggestion as to my concerns for the kind of upgrade script you mentioned, here: https://github.com/danielkocsis/liferay-portal/pull/590#issuecomment-270410362

Thank you!

Copying notes from previous pull request chain:

> Relevant tickets:


> https://issues.liferay.com/browse/LPP-23654
> https://issues.liferay.com/browse/LPS-69904
> 
> If there is a missing "last publish date" in the PortletPreferences for a portlet with content, then when publishing this content in staging, it will fail to create a new "last publish date" and all content associated it will always be marked as requiring publish, no matter how many times it is published.
> 
> This is due to a validation check implemented in LPS-50596, which will return false for most cases where the originalLastPublishDate is null. If it's not considered a valid range, then it will refrain from updating the PortletPreferences at all.
> 
> I'm not sure exactly why the validation was done in this way in the first place, so I tried to just change the logic to capture this one particular case; in this case, originalLastPublishDate and the startDate for the date range (since the last publish) are null, because the date was missing, but endDate is not null. The endDate would be at the time of the current publication process.
> 
> It is possible to achieve a situation like this via an upgrade from 6.0. Perhaps there could be more implemented to prevent the loss of this date in the first place, but since 6.0 seems like such an old version and no longer supported, I wasn't sure if this was something that would be worth doing. I figured updating the code for 7.0 and 6.2 to be able to handle this case would probably be a good enough solution on its own. Let me know if there is disagreement though.
> 
> Thank you.