### PR TITLE
[TECHNICAL-SUPPORT] LPS-72320

### DIFF
--- a/modules/apps/forms-and-workflow/.version-override-portal-workflow-definition-web.properties
+++ b/modules/apps/forms-and-workflow/.version-override-portal-workflow-definition-web.properties
@@ -1,1 +1,0 @@
-Bundle-Version=1.0.8

--- a/modules/apps/forms-and-workflow/.version-override-portal-workflow-instance-web.properties
+++ b/modules/apps/forms-and-workflow/.version-override-portal-workflow-instance-web.properties
@@ -1,1 +1,0 @@
-Bundle-Version=1.0.9

--- a/modules/apps/forms-and-workflow/.version-override-portal-workflow-kaleo-definition-impl.properties
+++ b/modules/apps/forms-and-workflow/.version-override-portal-workflow-kaleo-definition-impl.properties
@@ -1,1 +1,0 @@
-Bundle-Version=2.0.6

--- a/modules/apps/forms-and-workflow/.version-override-portal-workflow-kaleo-runtime-impl.properties
+++ b/modules/apps/forms-and-workflow/.version-override-portal-workflow-kaleo-runtime-impl.properties
@@ -1,1 +1,0 @@
-Bundle-Version=2.0.12

--- a/modules/apps/forms-and-workflow/.version-override-portal-workflow-task-web.properties
+++ b/modules/apps/forms-and-workflow/.version-override-portal-workflow-task-web.properties
@@ -1,1 +1,0 @@
-Bundle-Version=1.0.21

--- a/modules/apps/forms-and-workflow/portal-workflow/.gitattributes
+++ b/modules/apps/forms-and-workflow/portal-workflow/.gitattributes
@@ -1,1 +1,0 @@
-*.soy	text eol=lf

--- a/modules/apps/forms-and-workflow/portal-workflow/.gitrepo
+++ b/modules/apps/forms-and-workflow/portal-workflow/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = true
 	cmdver = liferay
-	commit = 5ad4d8765238a5dfda952b69b630d86e6d355f6d
+	commit = fdfd456beb5484f806b9c5bf46c0dbdc42dd63e5
 	mergebuttonmergecommits = false
 	mode = pull
-	parent = 84c9321fbe788dc512e3bd463091cc7c5627e9d6
+	parent = c84bcb961ef4ac8dd6d22fe36e714e9a37555fe1
 	remote = git@github.com:liferay/com-liferay-portal-workflow.git

--- a/modules/apps/forms-and-workflow/portal-workflow/portal-workflow-definition-web/bnd.bnd
+++ b/modules/apps/forms-and-workflow/portal-workflow/portal-workflow-definition-web/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Workflow Definition Web
 Bundle-SymbolicName: com.liferay.portal.workflow.definition.web
-Bundle-Version: 1.0.7
+Bundle-Version: 1.0.8
 Liferay-Releng-Module-Group-Description:
 Liferay-Releng-Module-Group-Title: Workflow
 Web-ContextPath: /portal-workflow-definition-web

--- a/modules/apps/forms-and-workflow/portal-workflow/portal-workflow-instance-web/bnd.bnd
+++ b/modules/apps/forms-and-workflow/portal-workflow/portal-workflow-instance-web/bnd.bnd
@@ -1,5 +1,5 @@
 Bundle-Name: Liferay Portal Workflow Instance Web
 Bundle-SymbolicName: com.liferay.portal.workflow.instance.web
-Bundle-Version: 1.0.8
+Bundle-Version: 1.0.9
 Liferay-Releng-Module-Group-Description:
 Liferay-Releng-Module-Group-Title: Workflow

--- a/modules/apps/forms-and-workflow/portal-workflow/portal-workflow-kaleo-definition-impl/bnd.bnd
+++ b/modules/apps/forms-and-workflow/portal-workflow/portal-workflow-kaleo-definition-impl/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Workflow Kaleo Definition Implementation
 Bundle-SymbolicName: com.liferay.portal.workflow.kaleo.definition.impl
-Bundle-Version: 2.0.5
+Bundle-Version: 2.0.6
 Liferay-Releng-Module-Group-Description:
 Liferay-Releng-Module-Group-Title: Kaleo Workflow Engine
 -dsannotations-options: inherit

--- a/modules/apps/forms-and-workflow/portal-workflow/portal-workflow-kaleo-runtime-impl/bnd.bnd
+++ b/modules/apps/forms-and-workflow/portal-workflow/portal-workflow-kaleo-runtime-impl/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Workflow Kaleo Runtime Implementation
 Bundle-SymbolicName: com.liferay.portal.workflow.kaleo.runtime.impl
-Bundle-Version: 2.0.11
+Bundle-Version: 2.0.12
 Liferay-Releng-Module-Group-Description:
 Liferay-Releng-Module-Group-Title: Kaleo Workflow Engine
 Liferay-Require-SchemaVersion: 2.0.3

--- a/modules/apps/forms-and-workflow/portal-workflow/portal-workflow-task-web/bnd.bnd
+++ b/modules/apps/forms-and-workflow/portal-workflow/portal-workflow-task-web/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Workflow Task Web
 Bundle-SymbolicName: com.liferay.portal.workflow.task.web
-Bundle-Version: 1.0.20
+Bundle-Version: 1.0.21
 Liferay-Releng-Module-Group-Description:
 Liferay-Releng-Module-Group-Title: Workflow
 Web-ContextPath: /portal-workflow-task-web

--- a/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/staging/StagingImpl.java
+++ b/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/staging/StagingImpl.java
@@ -2329,13 +2329,15 @@ public class StagingImpl implements Staging {
 	public void unschedulePublishToRemote(PortletRequest portletRequest)
 		throws PortalException {
 
-		long groupId = ParamUtil.getLong(portletRequest, "groupId");
+		long stagingGroupId = ParamUtil.getLong(
+			portletRequest, "stagingGroupId");
 
 		String jobName = ParamUtil.getString(portletRequest, "jobName");
 		String groupName = getSchedulerGroupName(
-			DestinationNames.LAYOUTS_REMOTE_PUBLISHER, groupId);
+			DestinationNames.LAYOUTS_REMOTE_PUBLISHER, stagingGroupId);
 
-		_layoutService.unschedulePublishToRemote(groupId, jobName, groupName);
+		_layoutService.unschedulePublishToRemote(
+			stagingGroupId, jobName, groupName);
 	}
 
 	@Override


### PR DESCRIPTION
Currently, the groupId is zero so when checking permissions in LayoutServiceImpl.unschedulePublishToRemote it fails. In scheduled_publish_processes.jsp, groupId is not passed but the stagingGroupId is so we should pull that parameter instead. 