### PR TITLE
LPS-70709 remote staging with cluster behind load balancer - updating of target group_ record is not atomic

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.backgroundtask.BackgroundTask;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTaskConstants;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTaskManagerUtil;
 import com.liferay.portal.kernel.cache.thread.local.ThreadLocalCachable;
+import com.liferay.portal.kernel.cluster.Clusterable;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.DuplicateGroupException;
 import com.liferay.portal.kernel.exception.GroupFriendlyURLException;
@@ -911,6 +912,7 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 		return deleteGroup(group);
 	}
 
+	@Clusterable(onMaster = true)
 	@Override
 	public synchronized void disableStaging(long groupId)
 		throws PortalException {
@@ -947,6 +949,7 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 		}
 	}
 
+	@Clusterable(onMaster = true)
 	@Override
 	public synchronized void enableStaging(long groupId)
 		throws PortalException {

--- a/portal-kernel/src/com/liferay/portal/kernel/service/GroupLocalService.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/GroupLocalService.java
@@ -17,6 +17,7 @@ package com.liferay.portal.kernel.service;
 import aQute.bnd.annotation.ProviderType;
 
 import com.liferay.portal.kernel.cache.thread.local.ThreadLocalCachable;
+import com.liferay.portal.kernel.cluster.Clusterable;
 import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.dao.orm.IndexableActionableDynamicQuery;
@@ -2060,8 +2061,10 @@ public interface GroupLocalService extends BaseLocalService,
 
 	public void deleteUserGroups(long userId, long[] groupIds);
 
+	@Clusterable(onMaster = true)
 	public void disableStaging(long groupId) throws PortalException;
 
+	@Clusterable(onMaster = true)
 	public void enableStaging(long groupId) throws PortalException;
 
 	/**


### PR DESCRIPTION
Hi,

Could you please review this PR.
https://issues.liferay.com/browse/LPS-70709
The fix is needed on ee-6.2.x but we need to added it to master as well. It is not possible to test the issue. Because the reproducible steps are very hard. But according Sorin the fix works.

Thanks!