### PR TITLE
[TECHNICAL-SUPPORT] LPS-87030 Page template propagation

### DIFF
--- a/portal-impl/src/com/liferay/portlet/sites/util/SitesImpl.java
+++ b/portal-impl/src/com/liferay/portlet/sites/util/SitesImpl.java
@@ -265,11 +265,17 @@ public class SitesImpl implements Sites {
 		ServiceContext serviceContext =
 			ServiceContextThreadLocal.getServiceContext();
 
-		serviceContext.setAttribute("layoutPrototypeLinkEnabled", linkEnabled);
-		serviceContext.setAttribute(
-			"layoutPrototypeUuid", layoutPrototype.getUuid());
+		Serializable originalLayoutPrototypeLinkEnabled =
+			(Serializable)serviceContext.getAttribute(
+				"layoutPrototypeLinkEnabled");
+		Serializable originalLayoutPrototypeUuid =
+			(Serializable)serviceContext.getAttribute("layoutPrototypeUuid");
 
 		try {
+			serviceContext.setAttribute(
+				"layoutPrototypeLinkEnabled", linkEnabled);
+			serviceContext.setAttribute(
+				"layoutPrototypeUuid", layoutPrototype.getUuid());
 			Locale targetSiteDefaultLocale = PortalUtil.getSiteDefaultLocale(
 				targetLayout.getGroupId());
 
@@ -285,6 +291,23 @@ public class SitesImpl implements Sites {
 				layoutPrototypeLayout.isIconImage(), iconBytes, serviceContext);
 		}
 		finally {
+			if (originalLayoutPrototypeLinkEnabled == null) {
+				serviceContext.removeAttribute("layoutPrototypeLinkEnabled");
+			}
+			else {
+				serviceContext.setAttribute(
+					"layoutPrototypeLinkEnabled",
+					originalLayoutPrototypeLinkEnabled);
+			}
+
+			if (originalLayoutPrototypeUuid == null) {
+				serviceContext.removeAttribute("layoutPrototypeUuid");
+			}
+			else {
+				serviceContext.setAttribute(
+					"layoutPrototypeUuid", originalLayoutPrototypeUuid);
+			}
+
 			LocaleThreadLocal.setSiteDefaultLocale(siteDefaultLocale);
 		}
 


### PR DESCRIPTION
Hi @danielkocsis ,

We had several issues caused by Page template propagation overwriting "layoutPrototypeLinkEnabled" and "layoutPrototypeUuid" attributes in the ServiceContext.
Most of these are happening when Page Template Propagation is used together with Page Versioning. Since the behavior was not clearly defined, using these two features together is discouraged now. However, we are going more towards allowing it (see details on LPP-31888).

Daniel Couso created a fix that prevents overwriting the ServiceContext. This will be the first step to implement a final fix that will allow Page Template Propagation working with Page Versioning together.

Please review the changes.

Thanks,
Vendel