### PR TITLE
[TECHNICAL-SUPPORT] LPS-81006 Allow delete and update comments on Live site

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/staging/permission/StagingPermissionImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/staging/permission/StagingPermissionImpl.java
@@ -86,6 +86,8 @@ public class StagingPermissionImpl implements StagingPermission {
 			!actionId.equals(ActionKeys.CONFIGURATION) &&
 			!actionId.equals(ActionKeys.CUSTOMIZE) &&
 			!actionId.equals(ActionKeys.DELETE) &&
+			!actionId.equals(ActionKeys.DELETE_DISCUSSION) &&
+			!actionId.equals(ActionKeys.UPDATE_DISCUSSION) &&
 			!actionId.equals(ActionKeys.VIEW) &&
 			group.hasLocalOrRemoteStagingGroup() &&
 			(Validator.isNull(portletId) || group.isStagedPortlet(portletId))) {


### PR DESCRIPTION
Hi @danielkocsis ,

We had a similar issue before, where adding comments were disabled on Live site: LPS-81408. It makes sense that someone with an Administrator role should be able to delete or edit those comments.

Please review my changes.

Thanks,
Vendel