### PR TITLE
[TECHNICAL-SUPPORT] LPS-88004 Allow delete and update comments on Live site

### DIFF
--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/internal/security/permission/resource/definition/BlogsEntryModelResourcePermissionDefinition.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/internal/security/permission/resource/definition/BlogsEntryModelResourcePermissionDefinition.java
@@ -20,6 +20,8 @@ import com.liferay.blogs.model.BlogsEntry;
 import com.liferay.blogs.service.BlogsEntryLocalService;
 import com.liferay.exportimport.kernel.staging.permission.StagingPermission;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermissionLogic;
 import com.liferay.portal.kernel.security.permission.resource.PortletResourcePermission;
@@ -68,9 +70,27 @@ public class BlogsEntryModelResourcePermissionDefinition
 			modelResourcePermissionLogicConsumer) {
 
 		modelResourcePermissionLogicConsumer.accept(
-			new StagedModelPermissionLogic<>(
+			new StagedModelPermissionLogic<BlogsEntry>(
 				_stagingPermission, BlogsPortletKeys.BLOGS,
-				BlogsEntry::getEntryId));
+				BlogsEntry::getEntryId) {
+
+				@Override
+				public Boolean contains(
+					PermissionChecker permissionChecker, String name,
+					BlogsEntry blogsEntry, String actionId) {
+
+					if (actionId.equals(ActionKeys.UPDATE_DISCUSSION) ||
+						actionId.equals(ActionKeys.DELETE_DISCUSSION)) {
+
+						return null;
+					}
+
+					return super.contains(
+						permissionChecker, name, blogsEntry, actionId);
+				}
+
+			});
+
 		modelResourcePermissionLogicConsumer.accept(
 			new WorkflowedModelPermissionLogic<>(
 				_workflowPermission, modelResourcePermission,

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/security/permission/resource/DLFileEntryModelResourcePermissionRegistrar.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/security/permission/resource/DLFileEntryModelResourcePermissionRegistrar.java
@@ -72,9 +72,30 @@ public class DLFileEntryModelResourcePermissionRegistrar {
 				_portletResourcePermission,
 				(modelResourcePermission, consumer) -> {
 					consumer.accept(
-						new StagedModelPermissionLogic<>(
+						new StagedModelPermissionLogic<DLFileEntry>(
 							_stagingPermission, DLPortletKeys.DOCUMENT_LIBRARY,
-							DLFileEntry::getFileEntryId));
+							DLFileEntry::getFileEntryId) {
+
+							@Override
+							public Boolean contains(
+								PermissionChecker permissionChecker,
+								String name, DLFileEntry dlFileEntry,
+								String actionId) {
+
+								if (actionId.equals(
+										ActionKeys.UPDATE_DISCUSSION) ||
+									actionId.equals(
+										ActionKeys.DELETE_DISCUSSION)) {
+
+									return null;
+								}
+
+								return super.contains(
+									permissionChecker, name, dlFileEntry,
+									actionId);
+							}
+
+						});
 					consumer.accept(
 						new DLFileEntryWorkflowedModelPermissionLogic(
 							modelResourcePermission));

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/security/permission/resource/JournalArticleModelResourcePermissionRegistrar.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/security/permission/resource/JournalArticleModelResourcePermissionRegistrar.java
@@ -80,9 +80,30 @@ public class JournalArticleModelResourcePermissionRegistrar {
 				_portletResourcePermission,
 				(modelResourcePermission, consumer) -> {
 					consumer.accept(
-						new StagedModelPermissionLogic<>(
+						new StagedModelPermissionLogic<JournalArticle>(
 							_stagingPermission, JournalPortletKeys.JOURNAL,
-							JournalArticle::getResourcePrimKey));
+							JournalArticle::getResourcePrimKey) {
+
+							@Override
+							public Boolean contains(
+								PermissionChecker permissionChecker,
+								String name, JournalArticle journalArticle,
+								String actionId) {
+
+								if (actionId.equals(
+										ActionKeys.UPDATE_DISCUSSION) ||
+									actionId.equals(
+										ActionKeys.DELETE_DISCUSSION)) {
+
+									return null;
+								}
+
+								return super.contains(
+									permissionChecker, name, journalArticle,
+									actionId);
+							}
+
+						});
 					consumer.accept(
 						new WorkflowedModelPermissionLogic<>(
 							_workflowPermission, modelResourcePermission,

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/security/permission/resource/WikiPageModelResourcePermissionRegistrar.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/security/permission/resource/WikiPageModelResourcePermissionRegistrar.java
@@ -74,9 +74,30 @@ public class WikiPageModelResourcePermissionRegistrar {
 				_portletResourcePermission,
 				(modelResourcePermission, consumer) -> {
 					consumer.accept(
-						new StagedModelPermissionLogic<>(
+						new StagedModelPermissionLogic<WikiPage>(
 							_stagingPermission, WikiPortletKeys.WIKI,
-							WikiPage::getResourcePrimKey));
+							WikiPage::getResourcePrimKey) {
+
+							@Override
+							public Boolean contains(
+								PermissionChecker permissionChecker,
+								String name, WikiPage wikiPage,
+								String actionId) {
+
+								if (actionId.equals(
+										ActionKeys.UPDATE_DISCUSSION) ||
+									actionId.equals(
+										ActionKeys.DELETE_DISCUSSION)) {
+
+									return null;
+								}
+
+								return super.contains(
+									permissionChecker, name, wikiPage,
+									actionId);
+							}
+
+						});
 					consumer.accept(
 						new WorkflowedModelPermissionLogic<>(
 							_workflowPermission, modelResourcePermission,


### PR DESCRIPTION
Hi @danielkocsis ,

After PR https://github.com/danielkocsis/liferay-portal/pull/687, we discussed with @lipusz what the best solution might be for this issue. We decided to override the `StagedModelPermissionLogic` for those entities, where comments can be added. I've checked the portal where we actually use the `*PermissionRegistrar` classes and found these:
* [BlogsEntry](https://github.com/liferay/liferay-portal/blob/65059440dfaf2b8b365a20f99e83e4cdb15478aa/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/internal/security/permission/resource/definition/BlogsEntryModelResourcePermissionDefinition.java)
* [DLFileEntry](https://github.com/liferay/liferay-portal/blob/61ba1ec88bfc5799a1c0dbcc849bda7dc3eb662a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/security/permission/resource/DLFileEntryModelResourcePermissionRegistrar.java)
* [JournalArticle](https://github.com/liferay/liferay-portal/blob/ad87fa7d1008e58825e7ac0e1b6d8c1104671d2b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/security/permission/resource/JournalArticleModelResourcePermissionRegistrar.java)
* [WikiPage](https://github.com/liferay/liferay-portal/blob/ad87fa7d1008e58825e7ac0e1b6d8c1104671d2b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/security/permission/resource/WikiPageModelResourcePermissionRegistrar.java)

Please review my changes.

Thanks,
Vendel