### PR TITLE
LPS-92307 Replace latest file entry version with the latest available version when change tracking is active

### DIFF
--- a/modules/apps/document-library/document-library-change-tracking-service/src/main/java/com/liferay/document/library/change/tracking/service/impl/CTDLFolderServiceImpl.java
+++ b/modules/apps/document-library/document-library-change-tracking-service/src/main/java/com/liferay/document/library/change/tracking/service/impl/CTDLFolderServiceImpl.java
@@ -14,18 +14,15 @@
 
 package com.liferay.document.library.change.tracking.service.impl;
 
-import com.liferay.change.tracking.CTManager;
-import com.liferay.change.tracking.model.CTEntry;
 import com.liferay.document.library.change.tracking.service.base.CTDLFolderServiceBaseImpl;
+import com.liferay.document.library.change.tracking.service.internal.service.CTDLFileEntryManager;
 import com.liferay.document.library.change.tracking.service.persistence.CTDLFolderFinderOverride;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFileVersion;
 import com.liferay.document.library.kernel.model.DLFolder;
-import com.liferay.document.library.kernel.service.DLFileVersionLocalService;
 import com.liferay.portal.kernel.bean.BeanReference;
 import com.liferay.portal.kernel.dao.orm.QueryDefinition;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermissionFactory;
@@ -121,19 +118,9 @@ public class CTDLFolderServiceImpl extends CTDLFolderServiceBaseImpl {
 
 		DLFileEntry fileEntry = (DLFileEntry)object;
 
-		Optional<CTEntry> ctEntryOptional =
-			_ctManager.getLatestModelChangeCTEntryOptional(
-				PrincipalThreadLocal.getUserId(), fileEntry.getFileEntryId());
-
-		if (!ctEntryOptional.isPresent()) {
-			return object;
-		}
-
-		Optional<DLFileVersion> fileVersionOptional = ctEntryOptional.map(
-			CTEntry::getModelClassPK
-		).map(
-			_dlFileVersionLocalService::fetchDLFileVersion
-		);
+		Optional<DLFileVersion> fileVersionOptional =
+			_ctdlFileEntryManager.getLatestFileVersion(
+				fileEntry.getUserId(), fileEntry.getFileEntryId());
 
 		if (!fileVersionOptional.isPresent()) {
 			return object;
@@ -161,11 +148,8 @@ public class CTDLFolderServiceImpl extends CTDLFolderServiceBaseImpl {
 				CTDLFolderServiceImpl.class, "_dlFolderModelResourcePermission",
 				DLFolder.class);
 
-	@ServiceReference(type = CTManager.class)
-	private CTManager _ctManager;
-
-	@ServiceReference(type = DLFileVersionLocalService.class)
-	private DLFileVersionLocalService _dlFileVersionLocalService;
+	@ServiceReference(type = CTDLFileEntryManager.class)
+	private CTDLFileEntryManager _ctdlFileEntryManager;
 
 	@BeanReference(type = CTDLFolderFinderOverride.class)
 	private CTDLFolderFinderOverride _dlFolderFinder;

--- a/modules/apps/document-library/document-library-change-tracking-service/src/main/java/com/liferay/document/library/change/tracking/service/internal/configuration/DLFileEntryCTConfigurationRegistrar.java
+++ b/modules/apps/document-library/document-library-change-tracking-service/src/main/java/com/liferay/document/library/change/tracking/service/internal/configuration/DLFileEntryCTConfigurationRegistrar.java
@@ -66,6 +66,7 @@ public class DLFileEntryCTConfigurationRegistrar {
 			).setVersionEntityByVersionEntityIdFunction(
 				_dlFileVersionLocalService::fetchDLFileVersion
 			).setVersionEntityDetails(
+
 				// todo: handle dependent models changes as well
 
 				// if DLFileEntry has dependencies, like document type,

--- a/modules/apps/document-library/document-library-change-tracking-service/src/main/java/com/liferay/document/library/change/tracking/service/internal/service/CTDLFileEntryLocalServiceWrapper.java
+++ b/modules/apps/document-library/document-library-change-tracking-service/src/main/java/com/liferay/document/library/change/tracking/service/internal/service/CTDLFileEntryLocalServiceWrapper.java
@@ -68,7 +68,8 @@ public class CTDLFileEntryLocalServiceWrapper
 			InputStream is, long size, ServiceContext serviceContext)
 		throws PortalException {
 
-		// todo: PortletFileRepository and other "system" entries should not be handled in CT
+		// todo: PortletFileRepository and other "system" entries should not be
+		//  handled in CT
 
 		DLFileEntry fileEntry = _ctManager.executeModelUpdate(
 			() -> super.addFileEntry(
@@ -110,11 +111,6 @@ public class CTDLFileEntryLocalServiceWrapper
 
 		return fileEntry;
 	}
-
-	// todo: wrapping the necessary getters to not just return the latest version
-
-	// Right now with the finder customisation we filter out the entries on the
-	// resource level, but display the latest versions always.
 
 	private void _registerChange(DLFileEntry fileEntry, int changeType)
 		throws PortalException {

--- a/modules/apps/document-library/document-library-change-tracking-service/src/main/java/com/liferay/document/library/change/tracking/service/internal/service/CTDLFileEntryManager.java
+++ b/modules/apps/document-library/document-library-change-tracking-service/src/main/java/com/liferay/document/library/change/tracking/service/internal/service/CTDLFileEntryManager.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.document.library.change.tracking.service.internal.service;
+
+import com.liferay.change.tracking.CTEngineManager;
+import com.liferay.change.tracking.CTManager;
+import com.liferay.change.tracking.model.CTEntry;
+import com.liferay.document.library.kernel.model.DLFileVersion;
+import com.liferay.document.library.kernel.service.DLFileVersionLocalService;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
+import com.liferay.portal.kernel.service.GroupLocalService;
+
+import java.util.Optional;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Luiz Marins
+ */
+@Component(immediate = true, service = CTDLFileEntryManager.class)
+public class CTDLFileEntryManager {
+
+	public Optional<DLFileVersion> getLatestFileVersion(
+		long userId, long fileEntryId) {
+
+		Optional<CTEntry> ctEntryOptional =
+			_ctManager.getLatestModelChangeCTEntryOptional(
+				PrincipalThreadLocal.getUserId(), fileEntryId);
+
+		if (!ctEntryOptional.isPresent()) {
+			Optional.empty();
+		}
+
+		Optional<DLFileVersion> fileVersionOptional = ctEntryOptional.map(
+			CTEntry::getModelClassPK
+		).map(
+			_dlFileVersionLocalService::fetchDLFileVersion
+		);
+
+		return fileVersionOptional;
+	}
+
+	public boolean isChangeTrackingEnabled(long groupId)
+		throws PortalException {
+
+		Group group = _groupLocalService.getGroup(groupId);
+
+		if (_ctEngineManager.isChangeTrackingEnabled(group.getCompanyId()) &&
+			_ctEngineManager.isChangeTrackingSupported(
+				group.getCompanyId(), DLFileVersion.class)) {
+
+			return true;
+		}
+
+		return false;
+	}
+
+	@Reference
+	private CTEngineManager _ctEngineManager;
+
+	@Reference
+	private CTManager _ctManager;
+
+	@Reference
+	private DLFileVersionLocalService _dlFileVersionLocalService;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
+
+}

--- a/modules/apps/document-library/document-library-change-tracking-service/src/main/java/com/liferay/document/library/change/tracking/service/internal/service/CTDLFileVersionLocalServiceWrapper.java
+++ b/modules/apps/document-library/document-library-change-tracking-service/src/main/java/com/liferay/document/library/change/tracking/service/internal/service/CTDLFileVersionLocalServiceWrapper.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.document.library.change.tracking.service.internal.service;
+
+import com.liferay.change.tracking.CTEngineManager;
+import com.liferay.change.tracking.CTManager;
+import com.liferay.change.tracking.model.CTEntry;
+import com.liferay.document.library.kernel.model.DLFileEntry;
+import com.liferay.document.library.kernel.model.DLFileVersion;
+import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
+import com.liferay.document.library.kernel.service.DLFileVersionLocalService;
+import com.liferay.document.library.kernel.service.DLFileVersionLocalServiceWrapper;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ServiceWrapper;
+
+import java.util.Optional;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Luiz Marins
+ */
+@Component(immediate = true, service = ServiceWrapper.class)
+public class CTDLFileVersionLocalServiceWrapper
+	extends DLFileVersionLocalServiceWrapper {
+
+	public CTDLFileVersionLocalServiceWrapper() {
+		super(null);
+	}
+
+	public CTDLFileVersionLocalServiceWrapper(
+		DLFileVersionLocalService dlFileVersionLocalService) {
+
+		super(dlFileVersionLocalService);
+	}
+
+	@Override
+	public DLFileVersion getLatestFileVersion(long userId, long fileEntryId)
+		throws PortalException {
+
+		// TODO low duplicate
+
+		DLFileEntry dlFileEntry = _dlFileEntryLocalService.fetchDLFileEntry(
+			fileEntryId);
+
+		if (!_isChangeTrackingEnabled(dlFileEntry.getGroupId())) {
+			super.getLatestFileVersion(userId, fileEntryId);
+		}
+
+		Optional<CTEntry> ctEntryOptional =
+			_ctManager.getLatestModelChangeCTEntryOptional(
+				PrincipalThreadLocal.getUserId(), fileEntryId);
+
+		if (!ctEntryOptional.isPresent()) {
+			super.getLatestFileVersion(userId, fileEntryId);
+		}
+
+		Optional<DLFileVersion> fileVersionOptional = ctEntryOptional.map(
+			CTEntry::getModelClassPK
+		).map(
+			_dlFileVersionLocalService::fetchDLFileVersion
+		);
+
+		if (!fileVersionOptional.isPresent()) {
+			super.getLatestFileVersion(userId, fileEntryId);
+		}
+
+		return fileVersionOptional.get();
+	}
+
+	// TODO low duplicate
+
+	private boolean _isChangeTrackingEnabled(long groupId)
+		throws PortalException {
+
+		Group group = _groupLocalService.getGroup(groupId);
+
+		if (_ctEngineManager.isChangeTrackingEnabled(group.getCompanyId()) &&
+			_ctEngineManager.isChangeTrackingSupported(
+				group.getCompanyId(), DLFileVersion.class)) {
+
+			return true;
+		}
+
+		return false;
+	}
+
+	@Reference
+	private CTEngineManager _ctEngineManager;
+
+	@Reference
+	private CTManager _ctManager;
+
+	@Reference
+	private DLFileEntryLocalService _dlFileEntryLocalService;
+
+	@Reference
+	private DLFileVersionLocalService _dlFileVersionLocalService;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
+
+}

--- a/modules/apps/document-library/document-library-change-tracking-service/src/main/java/com/liferay/document/library/change/tracking/service/internal/service/CTDLFolderServiceWrapper.java
+++ b/modules/apps/document-library/document-library-change-tracking-service/src/main/java/com/liferay/document/library/change/tracking/service/internal/service/CTDLFolderServiceWrapper.java
@@ -14,15 +14,11 @@
 
 package com.liferay.document.library.change.tracking.service.internal.service;
 
-import com.liferay.change.tracking.CTEngineManager;
 import com.liferay.document.library.change.tracking.service.CTDLFolderService;
-import com.liferay.document.library.kernel.model.DLFileVersion;
 import com.liferay.document.library.kernel.service.DLFolderService;
 import com.liferay.document.library.kernel.service.DLFolderServiceWrapper;
 import com.liferay.portal.kernel.dao.orm.QueryDefinition;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ServiceWrapper;
 
 import java.util.List;
@@ -50,7 +46,7 @@ public class CTDLFolderServiceWrapper extends DLFolderServiceWrapper {
 			boolean includeMountFolders, QueryDefinition<?> queryDefinition)
 		throws PortalException {
 
-		if (!_isChangeTrackingEnabled(groupId)) {
+		if (!_ctdlFileEntryManager.isChangeTrackingEnabled(groupId)) {
 			return super.getFoldersAndFileEntriesAndFileShortcuts(
 				groupId, folderId, mimeTypes, includeMountFolders,
 				queryDefinition);
@@ -66,7 +62,7 @@ public class CTDLFolderServiceWrapper extends DLFolderServiceWrapper {
 			boolean includeMountFolders, QueryDefinition<?> queryDefinition)
 		throws PortalException {
 
-		if (!_isChangeTrackingEnabled(groupId)) {
+		if (!_ctdlFileEntryManager.isChangeTrackingEnabled(groupId)) {
 			return super.getFoldersAndFileEntriesAndFileShortcutsCount(
 				groupId, folderId, mimeTypes, includeMountFolders,
 				queryDefinition);
@@ -78,28 +74,10 @@ public class CTDLFolderServiceWrapper extends DLFolderServiceWrapper {
 				queryDefinition);
 	}
 
-	private boolean _isChangeTrackingEnabled(long groupId)
-		throws PortalException {
-
-		Group group = _groupLocalService.getGroup(groupId);
-
-		if (_ctEngineManager.isChangeTrackingEnabled(group.getCompanyId()) &&
-			_ctEngineManager.isChangeTrackingSupported(
-				group.getCompanyId(), DLFileVersion.class)) {
-
-			return true;
-		}
-
-		return false;
-	}
+	@Reference
+	private CTDLFileEntryManager _ctdlFileEntryManager;
 
 	@Reference
 	private CTDLFolderService _ctDLFolderLocalService;
-
-	@Reference
-	private CTEngineManager _ctEngineManager;
-
-	@Reference
-	private GroupLocalService _groupLocalService;
 
 }


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-92307

@danielkocsis 
This is working for Documents and Media portlet.
I haven't tested other areas of the UI, Asset Publisher, adding file to a Basic web content for example.
Are those scope of this Story and this Subtask?

There's one source formatting issue:
`Use @BeanReference instead of @ServiceReference: ./src/main/java/com/liferay/document/library/change/tracking/service/impl/CTDLFolderServiceImpl.java 151` but if I change it to ServiceReference it's not injected correctly. Does it have something to do with my class name? Any suggestions?