### PR TITLE
LPS-95262 Edit options are not available on Documents and Media folder if staging is enabled

### DIFF
--- a/portal-impl/src/com/liferay/portal/model/impl/GroupImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/GroupImpl.java
@@ -1053,6 +1053,10 @@ public class GroupImpl extends GroupBaseImpl {
 				PortletDataHandler stagedPortletDataHandler =
 					stagedPortlet.getPortletDataHandlerInstance();
 
+				if (stagedPortletDataHandler == null) {
+					continue;
+				}
+
 				if (portletDataHandler.getServiceName().equals(
 						stagedPortletDataHandler.getServiceName())) {
 

--- a/portal-impl/src/com/liferay/portal/model/impl/GroupImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/GroupImpl.java
@@ -1053,21 +1053,13 @@ public class GroupImpl extends GroupBaseImpl {
 				PortletDataHandler stagedPortletDataHandler =
 					stagedPortlet.getPortletDataHandlerInstance();
 
-				String portletDataHandlerNamespace =
-					portletDataHandler.getNamespace();
-
-				String stagedDataHandlerNamespace =
-					stagedPortletDataHandler.getNamespace();
-
 				String portletDataHandlerServiceName =
 					portletDataHandler.getServiceName();
 
 				String stagedDataHandlerServiceName =
 					stagedPortletDataHandler.getServiceName();
 
-				if (portletDataHandlerNamespace.equals(
-						stagedDataHandlerNamespace) &&
-					portletDataHandlerServiceName.equals(
+				if (portletDataHandlerServiceName.equals(
 						stagedDataHandlerServiceName)) {
 
 					return GetterUtil.getBoolean(entry.getValue());

--- a/portal-impl/src/com/liferay/portal/model/impl/GroupImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/GroupImpl.java
@@ -1053,14 +1053,8 @@ public class GroupImpl extends GroupBaseImpl {
 				PortletDataHandler stagedPortletDataHandler =
 					stagedPortlet.getPortletDataHandlerInstance();
 
-				String portletDataHandlerServiceName =
-					portletDataHandler.getServiceName();
-
-				String stagedDataHandlerServiceName =
-					stagedPortletDataHandler.getServiceName();
-
-				if (portletDataHandlerServiceName.equals(
-						stagedDataHandlerServiceName)) {
+				if (portletDataHandler.getServiceName().equals(
+						stagedPortletDataHandler.getServiceName())) {
 
 					return GetterUtil.getBoolean(entry.getValue());
 				}

--- a/portal-impl/src/com/liferay/portal/model/impl/GroupImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/GroupImpl.java
@@ -1050,8 +1050,25 @@ public class GroupImpl extends GroupBaseImpl {
 					continue;
 				}
 
-				if (portletDataHandler.equals(
-						stagedPortlet.getPortletDataHandlerInstance())) {
+				PortletDataHandler stagedPortletDataHandler =
+					stagedPortlet.getPortletDataHandlerInstance();
+
+				String portletDataHandlerNamespace =
+					portletDataHandler.getNamespace();
+
+				String stagedDataHandlerNamespace =
+					stagedPortletDataHandler.getNamespace();
+
+				String portletDataHandlerServiceName =
+					portletDataHandler.getServiceName();
+
+				String stagedDataHandlerServiceName =
+					stagedPortletDataHandler.getServiceName();
+
+				if (portletDataHandlerNamespace.equals(
+						stagedDataHandlerNamespace) &&
+					portletDataHandlerServiceName.equals(
+						stagedDataHandlerServiceName)) {
 
 					return GetterUtil.getBoolean(entry.getValue());
 				}


### PR DESCRIPTION
Hi Dani,

If I'm not very much mistaken, this issue was caused by LPS-79312 where we introduced new portletDataHandlers (like DLPortletDataHandler - DLAdminPortletDataHandler).

As the connected portletDataHandlers  share the same serviceName this fix should solve the problem.

Notes from @matthewchan123:

> Issue:
> When staged content is disabled for all portlets, the admin user loses privileges to update content and change permissions in some applications like Documents and Media.
> 
> Cause:
> In isStagedPortlet() of GroupImpl, two polymorphic objects are compared with the default equals() inherited from Object class. This check fails because it looks at whether PortletDataHandler references point to the same object, when it ought to examine the association between PortletDataHandler and portlet.
> 
> Fix:
> We only need to verify that portlet classNames are alike here. It is possible to get part of the names through getServiceName() which are declared in interface PortletDataHandler, and when comparing objects using these String values, admin users retain their permission to edit content in unstaged portlet environments.
> 
> Note:
> The utilization of portletId for this check does NOT work in this case because DL staging settings are stored under DLAdminPortlet instead of DLPortlet.