### PR TITLE
LPS-95596 Make Overview Cards the same height

### DIFF
--- a/modules/apps/change-tracking/change-tracking-change-lists-web/src/main/resources/META-INF/resources/css/change_lists_overview_card.scss
+++ b/modules/apps/change-tracking/change-tracking-change-lists-web/src/main/resources/META-INF/resources/css/change_lists_overview_card.scss
@@ -6,13 +6,17 @@
 	border-width: 0.063rem;
 	margin-bottom: 1.5rem;
 	margin-top: 1.5rem;
-	min-height: 413px;
+	min-height: 26.5rem;
 	padding-bottom: 2rem;
 	padding-top: 1.5rem;
 
 	.overview-card-container {
 		padding-left: 1.5rem;
 		padding-right: 1.5rem;
+	}
+
+	.overview-card-sheet-block {
+		height: 6.5rem;
 	}
 
 	.overview-card-sheet-title {


### PR DESCRIPTION
Hey @danielkocsis,

[LPS-95596](https://issues.liferay.com/browse/LPS-95596)

The card height will break when the description length is more than 2lines.  [LPS-90809](https://issues.liferay.com/browse/LPS-90809) is relevant if we want to reproduce the issue properly, as the changes allow longer description text than 75char.

@rolandpakai reviewed the changes as well

Thanks,
